### PR TITLE
Fix index page and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,16 @@ To run the Python games locally, you need:
 You can play the games directly via GitHub Pages:
 
 1. Navigate to the [GitHub Pages site](https://devvyyxyz.github.io/100-python-games/).
-2. Select a game from the list and click the link to play it.
+2. Select a game from the list and click the link to play it. *(The site currently lists placeholders while games are being added.)*
 
 Alternatively, to run a game locally:
 
-1. Navigate to the game's directory:
-   ```sh
-   cd games/game1
-   ```
+1. Navigate to the game's directory once it exists (for example `games/game1`).
 2. Run the Python script:
    ```sh
    python game1.py
    ```
-3. Open `index.html` in a web browser to play the game if it supports web embedding.
+3. Open the game's `index.html` in a web browser if it supports web embedding.
 
 ## Contributing
 

--- a/index.html
+++ b/index.html
@@ -1,1 +1,37 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>100 Python Games</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 2em;
+            background-color: #f6f8fa;
+        }
+        h1 {
+            color: #333;
+        }
+        ul {
+            list-style: none;
+            padding: 0;
+        }
+        li {
+            margin: 0.5em 0;
+        }
+        .coming-soon {
+            color: #888;
+        }
+    </style>
+</head>
+<body>
+    <h1>100 Python Games</h1>
+    <p>This site will host playable versions of the games included in this repository. Content is currently a work in progress.</p>
+    <ul>
+        <li class="coming-soon">Game 1 - Coming Soon</li>
+        <li class="coming-soon">Game 2 - Coming Soon</li>
+        <!-- More games will appear here as they are added -->
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a placeholder `index.html` so the GitHub Pages site isn't blank
- clarify usage instructions in README

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*

------
https://chatgpt.com/codex/tasks/task_e_6840f66f6cac8331a8ecf8377306bc50